### PR TITLE
Add support for aliases

### DIFF
--- a/test/help-test.js
+++ b/test/help-test.js
@@ -25,7 +25,22 @@ describe('help', function () {
     gulpHelp(gulp);
     should(originalTaskFn.calledTwice).ok;
     should(originalTaskFn.calledWith('default', ['help'])).ok;
-    should(gulp.tasks.help.help).eql('Display this help text');
+    should(gulp.tasks.help.help).eql('Display this help text.');
+  });
+
+  it('should have a custom help text if passed', function () {
+    gulp = sinon.stub({task: noop, tasks: { help: {} }});
+    gulpHelp(gulp, { description: 'help text.' });
+    should(gulp.tasks.help.help).eql('help text.');
+  });
+
+  it('should create an alias if passed', function () {
+    gulp = sinon.stub({task: noop, tasks: { help: {} }});
+    originalTaskFn = gulp.task;
+    gulpHelp(gulp, { aliases: ['h', '?'] });
+    should(gulp.tasks.help.help).eql('Display this help text. Aliases: h, ?');
+    should(originalTaskFn.calledWith('h', ['help'])).ok;
+    should(originalTaskFn.calledWith('?', ['help'])).ok;
   });
 
   describe('should support old task definitions', function () {
@@ -88,6 +103,15 @@ describe('help', function () {
       should(originalTaskFn.calledThrice).ok;
       should(originalTaskFn.calledWith('newStyle', ['dep'], noop)).ok;
       should(gulp.tasks.newStyle.help).eql(undefined);
+    });
+
+    it('with aliases', function () {
+      gulp.task('newStyle', 'description.', [], noop, { aliases: ['new-style', 'nstyle'] });
+      should(originalTaskFn.callCount).eql(5);
+      should(originalTaskFn.calledWith('newStyle', [], noop)).ok;
+      should(originalTaskFn.calledWith('new-style', ['newStyle'], gulpHelp.noop)).ok;
+      should(originalTaskFn.calledWith('nstyle', ['newStyle'], gulpHelp.noop)).ok;
+      should(gulp.tasks.newStyle.help).eql('description. Aliases: new-style, nstyle');
     });
   });
 


### PR DESCRIPTION
This PR adds support for aliases and custom help description.
It is now possible to do this:

```
require('gulp-help')(gulp, { description: 'you are looking at it' })
```

=>

```
[gulp] Starting 'help'...

Usage:
  gulp [task]

Available tasks:
  help     you are looking at it

[gulp] Finished 'help' after 1.23 ms
```

Furthermore:

```
require('gulp-help')(gulp, { description: 'you are looking at it.', aliases: ['h', '?'] })
```

=>

```
node_modules/.bin/gulp 
node_modules/.bin/gulp h
node_modules/.bin/gulp ?
```

=>

```
[gulp] Starting 'help'...

Usage:
  gulp [task]

Available tasks:
  help     you are looking at it. Aliases: h, ?

[gulp] Finished 'help' after 1.05 ms
```

And one last thing:

```
require('gulp-help')(gulp, { description: 'you are looking at it.', aliases: ['h', '?'] });
gulp.task('version', 'prints the version.', [], function() {
  console.log(1);
}, {
  aliases: ['v', 'V']
});
```

=>

```
[gulp] Starting 'help'...

Usage:
  gulp [task]

Available tasks:
  help     you are looking at it. Aliases: h, ?
  version  prints the version. Aliases: v, V

[gulp] Finished 'help' after 928 μs
```
