### PR TITLE
Allow the user define a callback once the help has been printed

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var gulpHelp = module.exports = function (gulp, options) {
 
   options = _.extend({
     aliases: [],
-    description: 'Display this help text.'
+    description: 'Display this help text.',
+    afterPrintCallback: gulpHelp.noop
   }, options);
 
   gulp.task = function (name, help, dep, fn, taskOptions) {
@@ -88,6 +89,9 @@ var gulpHelp = module.exports = function (gulp, options) {
       }
     });
     console.log('');
+    if (options.afterPrintCallback) {
+      options.afterPrintCallback(gulp.tasks);
+    }
   }, options);
 
   gulp.task('default', false, ['help']);


### PR DESCRIPTION
This PR allows the following:

```
require('gulp-help')(gulp, { afterPrintCallback: function(tasks) {
  console.log(tasks)
}})
```

The callback gets executed once the help has been printed and allows the dev to print some additional data.
