### PR TITLE
Only take visible tasks into account for the margin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ var gulpHelp = module.exports = function (gulp, options) {
   gulp.task('help', options.description, [], function () {
     var tasks  = Object.keys(gulp.tasks).sort();
     var margin = tasks.reduce(function(m, taskName) {
-      if ((ignoredTasks.indexOf(taskName) > -1) || (m > taskName.length)) {
+      if (_.contains(ignoredTasks, taskName) || (m > taskName.length)) {
         return m;
       } else {
         return taskName.length;


### PR DESCRIPTION
Previously the margin was calculated also based on invisible task names.
