### PR TITLE
Ensure 'help' is always the first task in the 'help' menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,12 @@ module.exports = function (gulp, options) {
     console.log('  gulp [task]');
     console.log('');
     console.log(gutil.colors.underline('Available tasks'));
-    tasks.forEach(function (name) {
+
+    // ensure help is always first
+
+    ['help'].concat(tasks.filter(function (task) {
+      return task !== 'help';
+    })).forEach(function (name) {
       if (gulp.tasks[name].help) {
         var helpText = gulp.tasks[name].help.message || '';
         var args = [' ', gutil.colors.cyan(name)];


### PR DESCRIPTION
Very small change but I thought it might be more appropriate for help to always be listed as the first item in the help menu.
