### PR TITLE
support for gulp 4.0, also changed argument order

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,138 +1,130 @@
 'use strict';
 
-var gutil = require('gulp-util'),
-  _ = require('lodash'),
-  attachHelp = require('./lib/attach-help.js'),
-  calculateMargin = require('./lib/calculate-margin.js'),
-  DEFAULT_OPTIONS = {
-    aliases: [],
-    description: 'Display this help text.',
-    afterPrintCallback: gutil.noop
-  };
+var gutil           = require('gulp-util'),
+    _               = require('lodash'),
+    attachHelp      = require('./lib/attach-help.js'),
+    calculateMargin = require('./lib/calculate-margin.js'),
+    DEFAULT_OPTIONS = {
+        aliases: [],
+        description: 'Display this help text.',
+        afterPrintCallback: gutil.noop
+    };
 
 module.exports = function (gulp, options) {
-  var originalTaskFn = gulp.task;
+    var originalTaskFn = gulp.task;
 
-  options = _.defaults({}, options, DEFAULT_OPTIONS);
+    options = _.defaults({}, options, DEFAULT_OPTIONS);
 
-  /**
-   * gulp.task(name[, help, deps, fn, taskOptions])
-   *
-   * Adds `help` and `taskOptions` to the typical gulp task definition:
-   * https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulptaskname-deps-fn
-   * @param {string} name
-   * @param {string | boolean} [help]
-   * @param {Array} [deps]
-   * @param {function} [fn]
-   * @param {object} [taskOptions]
-   */
-  gulp.task = function (name, help, deps, fn, taskOptions) {
-    var task;
+    /**
+     * gulp.task(name[, help, deps, fn, taskOptions])
+     *
+     * Adds `help` and `taskOptions` to the typical gulp task definition:
+     * https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulptaskname-deps-fn
+     * @param {string} name
+     * @param {string | boolean} [help]
+     * @param {Array} [deps]
+     * @param {function} [fn]
+     * @param {object} [taskOptions]
+     */
+    gulp.task = function (name, help, taskOptions, fn) {
 
-    /* jshint noempty: false */
-    if (name && (help === null || help === undefined)) {
-      // just a name. do nothing.
-    } else if (help === false) {
-      // .task('test', false, ...)
-      //ignoredTasks.push(name);
-      if (typeof deps === 'function') {
-        // .task('test', false, function(){}, {})
-        taskOptions = fn;
-        fn = deps;
-        deps = undefined;
-      } else {
-        // .task('test', false, ['dep'], function(){}, {})
-        // nothing needs to be re-assigned
-      }
-    } else if (typeof help === 'function') {
-      // .task('test', function(){})
-      taskOptions = deps;
-      fn = undefined;
-      deps = help;
-      help = undefined;
-    } else if (Array.isArray(help)) {
-      // .task('test', ['dep'], ...)
-      taskOptions = fn;
-      fn = deps;
-      deps = help;
-      help = undefined;
-    } else if (name && !deps) {
-      // .task('test', '...')
-      // help text with no func and no deps
-    } else if (typeof deps === 'function') {
-      // .task('test', '...', function, {})
-      taskOptions = fn;
-      fn = deps;
-      deps = undefined;
-    } else if (Array.isArray(deps)) {
-      // .task('test', '...', ['dep'], function, {})
-      // nothing needs to be re-assigned
-    } else {
-      throw new gutil.PluginError('gulp-help', 'Unexpected arg types. Should be in the form: `gulp.task(name[, help, deps, fn, taskOptions])`');
-    }
+        // if `gulp.task('onlyname')' was supplied, just return the existing task itself
+        if (arguments.length === 1 && typeof name === 'string') {return originalTaskFn.call(gulp, name);}
 
-    if (!deps) {
-      originalTaskFn.call(gulp, name, fn);
-    } else {
-      originalTaskFn.call(gulp, name, deps, fn);
-    }
+        var task;
 
-    task = gulp.tasks[name];
+        /* jshint noempty: false */
 
-    taskOptions = _.extend({
-      aliases: []
-    }, taskOptions);
+        var args = Array.prototype.slice.call(arguments);
 
+        fn = args.pop();
 
-    taskOptions.aliases.forEach(function (alias) {
-      gulp.task(alias, false, [ name ], gutil.noop);
-    });
+        if (typeof args[0] === 'string') {
+            name = args.shift()
+            if (typeof args[0] === 'string') {
+                help = args.shift();
+            }
+        }
 
-    attachHelp(task, help, taskOptions);
+        if (typeof args[0] === 'object') {
+            taskOptions = args.shift();
+        }
 
-    return gulp;
-  };
+        if (args.length !== 0 || !fn || !(name || fn.name)) {
+            throw new gutil.PluginError('gulp-help',
+                'Unexpected arg types. Should be in the form: `gulp.task([name, help, taskOptions, ] fn)` but received: \n ' + Array.prototype.slice.call(arguments));
+        }
 
-  gulp.task('help', options.description, function () {
-    var marginData = calculateMargin(gulp.tasks);
-    var margin = marginData.margin;
+        if (name) {
+            originalTaskFn.call(gulp, name, fn)
+        } else {
+            originalTaskFn.call(gulp, fn)
+        }
 
-    // set options buffer if the tasks array has options
-    var optionsBuffer = marginData.hasOptions ? '  --' : '';
+        task = originalTaskFn.call(gulp, name);
 
-    console.log('');
-    console.log(gutil.colors.underline('Usage'));
-    console.log('  gulp [task]');
-    console.log('');
-    console.log(gutil.colors.underline('Available tasks'));
-    Object.keys(gulp.tasks).sort().forEach(function (name) {
-      if (gulp.tasks[name].help || process.argv.indexOf('--all') !== -1) {
-        var help = gulp.tasks[name].help || { message: '', options: {} };
-        var helpText = help.message || '';
-        var args = [' ', gutil.colors.cyan(name)];
+        taskOptions = _.extend({
+            aliases: []
+        }, taskOptions);
 
-        args.push(new Array(margin - name.length + 1 + optionsBuffer.length).join(" "));
-        args.push(helpText);
-
-        var options = Object.keys(help.options).sort();
-        options.forEach(function (option) {
-          var optText = help.options[option];
-          args.push('\n ' + optionsBuffer + gutil.colors.cyan(option) + ' ');
-
-          args.push(new Array(margin - option.length + 1).join(" "));
-          args.push(optText);
+        taskOptions.aliases.forEach(function (alias) {
+            originalTaskFn.task(alias, fn);
         });
 
-        console.log.apply(console, args);
-      }
+        attachHelp(task, help, taskOptions);
+
+        return gulp;
+    };
+
+    gulp.task('help', options.description, options, function () {
+
+        var tasksWrapped = gulp.registry().tasks();
+
+        var tasksWithMetadata = {};
+        Object.keys(tasksWrapped).sort().forEach(function (key) {tasksWithMetadata[key] = gulp.task(key)});
+
+        var marginData = calculateMargin(tasksWithMetadata);
+        var margin = marginData.margin;
+
+        // set options buffer if the tasks array has options
+        var optionsBuffer = marginData.hasOptions ? '  --' : '';
+
+        console.log('');
+        console.log(gutil.colors.underline('Usage'));
+        console.log('  gulp [task]');
+        console.log('');
+        console.log(gutil.colors.underline('Available tasks'));
+
+        _.each(tasksWithMetadata, function (task, name) {
+
+            if (task.help || process.argv.indexOf('--all') !== -1) {
+
+                var help = task.help || {message: '', options: {}};
+                var helpText = help.message || '';
+                var args = [' ', gutil.colors.cyan(name)];
+
+                args.push(new Array(margin - name.length + 1 + optionsBuffer.length).join(" "));
+                args.push(helpText);
+
+                var options = Object.keys(help.options).sort();
+                options.forEach(function (option) {
+                    var optText = help.options[option];
+                    args.push('\n ' + optionsBuffer + gutil.colors.cyan(option) + ' ');
+
+                    args.push(new Array(margin - option.length + 1).join(" "));
+                    args.push(optText);
+                });
+
+                console.log.apply(console, args);
+            }
+        });
+        console.log('');
+        if (options.afterPrintCallback) {
+            options.afterPrintCallback(tasksWithMetadata);
+        }
     });
-    console.log('');
-    if (options.afterPrintCallback) {
-      options.afterPrintCallback(gulp.tasks);
-    }
-  }, options);
 
-  gulp.task('default', false, ['help']);
+    gulp.task('default', gulp.task('help'));
 
-  return gulp;
+    return gulp;
 };


### PR DESCRIPTION
- new argument order: gulp.task([name, help, taskOptions, ] fn)

Hi, this was a quick n dirty modification to make it work with gulp 4.0. I don't expect you to merge this in right away - it's just for review / inspiration.
I won't work on this the next 3 weeks (too busy), but it works already for my purposes :-)

Limitations so far:
- tests not adapted
- no support for hiding tasks
