### PR TITLE
[bugfix] Rewrite `task.help` of a task being rewritten

### DIFF
--- a/lib/attach-help.js
+++ b/lib/attach-help.js
@@ -1,18 +1,25 @@
 'use strict';
 
 module.exports = function (task, msg, taskOptions) {
-  if (task && msg !== false) {
-    msg = (typeof msg === 'string') ? msg : '';
-    if (taskOptions.aliases && taskOptions.aliases.length > 0) {
-      if (msg.length > 0) {
-        msg += ' ';
-      }
-      msg += 'Aliases: ' + taskOptions.aliases.join(', ');
-    }
-
-    task.help = {
-      message: msg,
-      options: taskOptions.options || {}
-    };
+  if (!task) {
+    return;
   }
+
+  if (msg === false) {
+    delete task.help;
+    return;
+  }
+
+  msg = (typeof msg === 'string') ? msg : '';
+  if (taskOptions.aliases && taskOptions.aliases.length > 0) {
+    if (msg.length > 0) {
+      msg += ' ';
+    }
+    msg += 'Aliases: ' + taskOptions.aliases.join(', ');
+  }
+
+  task.help = {
+    message: msg,
+    options: taskOptions.options || {}
+  };
 };

--- a/tests.js
+++ b/tests.js
@@ -309,6 +309,14 @@ describe('help', function () {
       should(gulp.tasks.newStyle.help.message).eql('Aliases: new-style, nstyle');
     });
 
+    it('should replace help message of a task being rewritten', function () {
+      gulp.task('newStyle', gutil.noop);
+      gulp.task('newStyle', false, gutil.noop);
+      should(originalTaskFn.callCount).eql(4);
+      should(originalTaskFn.calledWith('newStyle', gutil.noop)).ok;
+      should(gulp.tasks.newStyle.help).eql(undefined);
+    });
+
   });
 
   describe('should throw error', function () {


### PR DESCRIPTION
In my case sometimes I have to rewrite a gulp task (because I use tasks from other library and then rewrite some of them) - but the help message stays the same, even if I want to hide it. This fixes it.
Test included.