### PR TITLE
Allow custom default task

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ module.exports = function (gulp, options) {
     }
   }, options);
 
-  gulp.task('default', false, ['help']);
+  if(gulp.tasks['default'] === undefined) gulp.task('default', false, ['help']);
 
   return gulp;
 };


### PR DESCRIPTION
Currently, the `default` task is overriden by gulp-help.  Checking if there is a default task already defined solves the problem.