### PR TITLE
check for null values in attach-help

### DIFF
--- a/lib/attach-help.js
+++ b/lib/attach-help.js
@@ -16,7 +16,7 @@ module.exports = function (task, msg, deps, taskOptions) {
   }
 
   var depsMessage = '';
-  if (typeof deps === 'object' && deps.length > 0) {
+  if (deps && typeof deps === 'object' && deps.length > 0) {
     depsMessage = '[' + deps.join(', ') + ']';
   }
 


### PR DESCRIPTION
`null` is an object as well. Checking length would throw an error.

Probably this is mostly due to my use case, but I have:
```javascript
function productionOnly(fx){
    return (condition) ? null : fx
}

gulp.task('js', 'Help Text', productionOnly(function() {
 // Do Something
}));
```

and as such

```
TypeError: Cannot read property 'length' of null
    at module.exports (/repo/node_modules/gulp-help/lib/attach-help.js:20:39)
```