### PR TITLE
Fix looking for description in wrapped gulp task function

### DIFF
--- a/lib/logTasks.js
+++ b/lib/logTasks.js
@@ -19,8 +19,12 @@ module.exports = function (gulp, options) {
   logger(tasksHeadingStyler(options.tasksHeadingText));
 
   Object.keys(tasks).forEach(function (taskName) {
-    
+
     var task = gulp.task(taskName);
+
+    while (typeof task['unwrap'] === 'function') {
+        task = task.unwrap();
+    }
 
     if (task.hide) return; // skip displaying this task
 


### PR DESCRIPTION
Gulp task functions are wrapped inside a wrapper function … unwrap the
tasks first to look for the description.

https://github.com/gulpjs/undertaker/commit/67fd02cdc217326cab2aa3d1d7be
ca9ea12cfde6
