### PR TITLE
Add missing beforePrintCallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var objectAssign = require('object-assign'),
   DEFAULT_OPTIONS = {
     aliases: [],
     description: 'Display this help text.',
+    beforePrintCallback: noop,
     afterPrintCallback: noop,
     hideDepsMessage: false,
     hideEmpty: false
@@ -100,7 +101,12 @@ module.exports = function (gulp, options) {
     var hideDepsMessageOpt = options.hideDepsMessage;
     var hideEmptyOpt = options.hideEmpty;
     var showAllTasks = process.argv.indexOf('--all') !== -1;
+    var beforePrintCallback = options.beforePrintCallback;
     var afterPrintCallback = options.afterPrintCallback;
+
+    if (beforePrintCallback) {
+      beforePrintCallback(gulp.tasks);
+    }
 
     // set options buffer if the tasks array has options
     var optionsBuffer = marginData.hasOptions ? '  --' : '';

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ These are all the options available to be passed to the `gulp-help` instance, NO
 - `aliases` - adds aliases to the default help task
 - `hideEmpty` - hide all tasks with no help message defined. Useful when including 3rd party tasks
 - `hideDepsMessage` - hide all task dependencies
+- `beforePrintCallback` - a function to run before the default help task runs
 - `afterPrintCallback` - a function to run after the default help task runs
 
 ## License


### PR DESCRIPTION
This PR adds a `beforePrintCallback` config option which allows to add a function to execute before the default `help` task runs.

It can be used for example for displaying the project logo in ascii art before the help message :-)

```
             _             _          _       
  __ _ _   _| |_ __       | |__   ___| |_ __  
 / _` | | | | | '_ \ _____| '_ \ / _ \ | '_ \ 
| (_| | |_| | | |_) |_____| | | |  __/ | |_) |
 \__, |\__,_|_| .__/      |_| |_|\___|_| .__/ 
 |___/        |_|                      |_|    

```
