### PR TITLE
unwrap gulp tasks to access static properties

### DIFF
--- a/lib/logTasks.js
+++ b/lib/logTasks.js
@@ -20,7 +20,7 @@ module.exports = function (gulp, options) {
 
   Object.keys(tasks).forEach(function (taskName) {
     
-    var task = gulp.task(taskName);
+    var task = gulp.task(taskName).unwrap();
 
     if (task.hide) return; // skip displaying this task
 


### PR DESCRIPTION
When I tried to get this branch work it didn't show task descriptions. 
After further inspection I saw that the task functions are wrapped and can be 
unwrapped with the `unwrap` method. Now it works for me.